### PR TITLE
Avs check add required fields + some fixes

### DIFF
--- a/src/Gateways/RealexConnector.ts
+++ b/src/Gateways/RealexConnector.ts
@@ -431,6 +431,22 @@ export class RealexConnector extends XmlGateway implements IRecurringService {
         cData(builder.reasonCode.toString()),
       );
     }
+    if (builder.shippingAddress) {
+        subElement(request, "shipping_code").append(
+          cData(builder.shippingAddress.shipping_code || builder.shippingAddress.postalCode || "")
+        );
+        subElement(request, "shipping_co").append(
+          cData(builder.shippingAddress.country || "")
+        );
+    }
+    if (builder.billingAddress) {
+        subElement(request, "billing_code").append(
+          cData(builder.billingAddress.billing_code || builder.billingAddress.postalCode || "")
+        );
+        subElement(request, "billing_co").append(
+          cData(builder.billingAddress.country || "")
+        );
+    }
 
     if (builder.description) {
       const comments = subElement(request, "comments");

--- a/src/Gateways/RealexConnector.ts
+++ b/src/Gateways/RealexConnector.ts
@@ -293,7 +293,7 @@ export class RealexConnector extends XmlGateway implements IRecurringService {
       request.SHIPPING_CODE = encoder(builder.shippingAddress.postalCode || "");
       request.SHIPPING_CO = encoder(builder.shippingAddress.country || "");
     }
-    if (builder.sillingAddress) {
+    if (builder.billingAddress) {
       request.BILLING_CODE = encoder(builder.billingAddress.postalCode || "");
       request.BILLING_CO = encoder(builder.billingAddress.country || "");
     }


### PR DESCRIPTION
What's been added:

- fix a typo with billing address
- use checkResponse to parse the error code and message, (dry)
- checkResponse now is now able to parse realex html error pages
- added address billing/shipping code and co for avs checks